### PR TITLE
Workflow for creating GH releases with compiled themes

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,30 @@
+name: Release on tag
+
+on:
+  push:
+    tags: [ "*" ]
+
+jobs:
+  build-and-release:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y git make inkscape x11-apps
+
+    - name: Build dist-folders
+      run: make build
+
+    - name: Generate tar-files
+      run: make dist/material_*cursors
+
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "material_*cursors*.tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ undo_release: _get_version
 	-git tag -d $(VERSION)
 	-git push --delete origin $(VERSION)
 
-$(CURSOR_THEMES):
+$(CURSOR_THEMES): _get_version
 	cp -f AUTHORS LICENSE $@
 	tar -C $(dir $@) -czf $(notdir $@)_$(VERSION).tar.gz $(notdir $@)
 


### PR DESCRIPTION
I just set up a workflow for your repository to create releases containing the `.tar.gz`-files for every cursor theme.  
The release would be automatically generated any time you create a [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on some commit. That way you can decide which commits warrant their own releases.

Also, I added a little fix for your `Makefile`, which was necessary to use the `VERSION`-variable in that make-case.

---

I hope that this is useful to you, because it enables me/others to find a compiled version of these icons that isn't on Pling (where they force people to manually load the latest files, prevent any scriptable access, afaict).  
I made sure that this [wouldn't cost you anything to deploy](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions), as long as the repository is public.  
Lastly, to give you an idea, my tests on the GH-hosted runners ran for <10 minutes each time. (I cleaned up, but I think I'll add another tag to enable you to see for yourself on my fork.)

---

Hope that clears up any questions, and that you find this to be a sensible contribution to your project.  
If not, please let me know, if you have any concerns with me keeping my public fork going and periodically building my own releases. (I'd like to keep it public to not incur any bills for it. ;) )